### PR TITLE
Mention automatic feed discovery support

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,6 +52,8 @@ and **paste in the Feed URL.**
 
 **You're done!** You can now read the latest content in your newsreader.
 
+Sometimes, websites won’t have a link to an RSS feed. That doesn’t mean you’re out of luck, though! Some popular blog platforms create RSS feeds by default, and newsreader apps are sometimes able to find those feeds automatically. If you can’t find an RSS link on a page, try adding the URL of the page you’re on to your newsreader app.
+
 
 # Who made this site?
 


### PR DESCRIPTION
This is a little wordy and may be unclear so I’d really appreciate any help you can give for tightening it up!

At least Feedly, and probably other newsreader apps too, support scraping an HTML page to find `<link>` meta tags that tell them where to find an RSS feed. Even if a WordPress blog uses a theme that doesn’t have a visible link to the feed, those meta tags will often still be present and functional.