### PR TITLE
Add lang attribute

### DIFF
--- a/tools/pretty-feed-v3.xsl
+++ b/tools/pretty-feed-v3.xsl
@@ -70,7 +70,7 @@ This file is in BETA. Please test and contribute to the discussion:
                 xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
   <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
   <xsl:template match="/">
-    <html xmlns="http://www.w3.org/1999/xhtml">
+    <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
       <head>
         <title><xsl:value-of select="/rss/channel/title"/> Web Feed</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>


### PR DESCRIPTION
The html element must have a lang attribute for accessibility reasons.

See: https://www.w3.org/TR/WCAG21/#language-of-page