### PR TITLE
Add `rel="noreferrer"` to external links in `pretty-feed-v3.xsl`

### DIFF
--- a/tools/pretty-feed-v3.xsl
+++ b/tools/pretty-feed-v3.xsl
@@ -111,7 +111,7 @@ This file is in BETA. Please test and contribute to the discussion:
             </h1>
             <h2><xsl:value-of select="/rss/channel/title"/></h2>
             <p><xsl:value-of select="/rss/channel/description"/></p>
-            <a class="head_link" target="_blank">
+            <a class="head_link" target="_blank" rel="noreferrer">
               <xsl:attribute name="href">
                 <xsl:value-of select="/rss/channel/link"/>
               </xsl:attribute>
@@ -122,7 +122,7 @@ This file is in BETA. Please test and contribute to the discussion:
           <xsl:for-each select="/rss/channel/item">
             <div class="pb-5">
               <h3 class="mb-0">
-                <a target="_blank">
+                <a target="_blank" rel="noreferrer">
                   <xsl:attribute name="href">
                     <xsl:value-of select="link"/>
                   </xsl:attribute>


### PR DESCRIPTION
[This prevents potential security vulnerabilities.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#security_and_privacy)

This is unlikely to be an issue since the website being linked to is presumably controlled by the same person creating the RSS feed. However, it is still best practice to add `rel="noreferrer"` just to be safe.

Commonly, you might see `noopener` added in as well but `noreferrer` already includes `nooepener` implicitly so that would be redundant.